### PR TITLE
feat: Finish ESM

### DIFF
--- a/build/build.docs.js
+++ b/build/build.docs.js
@@ -1,11 +1,10 @@
-'use strict'
+import fs from 'fs'
+import TypeDoc from 'typedoc'
+import path from 'path'
 
-const fs = require('fs')
-const TypeDoc = require('typedoc')
-const path = require('path')
-const pkgJson = require('../package.json')
+const pkgJson = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
 
-const rootDir = path.join(__dirname, '..')
+const rootDir = new URL('../', import.meta.url).pathname
 
 function camelise (str) {
   return str.replace(/-([a-z])/g,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "engines": {
     "node": ">=10.4.0"
   },
+  "type": "module",
   "types": "./types/index.d.ts",
   "main": "./dist/cjs/index.node.cjs",
   "browser": "./dist/esm/index.browser.js",


### PR DESCRIPTION
Apparently, I can not use ESM bundle of the package. Node complains that despite export-map, exported file `./dist/esm/index.node.js` is not a ES module. Here I propose a fix for that. Now ESM packages dependent on this package can use `bigint-mod-arith` all right. This is rationale for `type: module` in `package.json`.

As for changes in `build.docs.js`, now Nodejs treats every `.js` file as ESM. Had to adjust the file, so that it does not affect the build process.